### PR TITLE
[ Logger ] initialization was added to Bundle->boot()

### DIFF
--- a/FpBadaBoomBundle.php
+++ b/FpBadaBoomBundle.php
@@ -1,6 +1,8 @@
 <?php
 namespace Fp\BadaBoomBundle;
 
+use BadaBoom\Bridge\Psr\Logger;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -90,9 +92,13 @@ class FpBadaBoomBundle extends Bundle
         $chainNodeManager = $this->container->get('fp_badaboom.chain_node_manager');
 
         $exceptionCatcher->start($this->container->getParameter('kernel.debug'));
+
+        /** @var $logger Logger */
+        $logger = $this->container->get('fp_badaboom.logger');
         
         foreach ($chainNodeManager->all() as $chainNode) {
             $exceptionCatcher->registerChainNode($chainNode);
+            $logger->registerChain($chainNode);
         }
     }
 }


### PR DESCRIPTION
@makasim please review
This fix is required to use Logger in RemixJobs
